### PR TITLE
Fix broken links

### DIFF
--- a/scripts/overrides/tei_to_html.xsl
+++ b/scripts/overrides/tei_to_html.xsl
@@ -266,9 +266,21 @@
       <!-- when there is no @n treat this as an internal link to another document
       todo: determine if this can be added to the datura script more universally-->
       <xsl:when test="not(@n)">
-        <a href="{@target}">
-          <xsl:apply-templates/>
-        </a>
+        <xsl:variable name="uri" select="concat('../../source/tei/',@target,'.xml')"/>
+        <xsl:choose>
+          <xsl:when test="contains(@target,'zzz') or contains(@target,'per') or contains(@target,'ppp')">
+            <a href="{@target}">
+              <xsl:apply-templates/>
+            </a>
+          </xsl:when>
+          <!-- check to see if file exists -->
+        <xsl:when test="doc-available($uri)">
+          <a href="{@target}">
+            <xsl:apply-templates/>
+          </a>
+        </xsl:when>
+          <xsl:otherwise><xsl:apply-templates/></xsl:otherwise>
+        </xsl:choose>
       </xsl:when>
       <!-- WHITMAN NOTES -->
       <xsl:when test=". = '' and @n">


### PR DESCRIPTION
This is a challenging one because of the fact that notes might link to documents anywhere on the Archive. This PR creates an option that allows link creation for any `<ref>` in notes with `@target` including 'zzz' (for images), 'per' (for journalism), and 'ppp' (for LG editions). For everything else in WWA IDs, this checks to see if the file exists in the correspondence tei repo before creating a link. This seems to address the examples generated in the issue (https://github.com/whitmanarchive/whitman-issues/issues/789) but might run into trouble if, for instance, a manuscript or notebook is linked from a note. Discuss before implementing. 